### PR TITLE
Add typia.tags.NoRuntimeCheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typia",
+  "name": "@matatbread/typia",
   "version": "6.8.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
@@ -104,6 +104,5 @@
     "package.json",
     "lib",
     "src"
-  ],
-  "private": true
+  ]
 }

--- a/src/factories/internal/metadata/iterate_metadata_intersection.ts
+++ b/src/factories/internal/metadata/iterate_metadata_intersection.ts
@@ -6,6 +6,7 @@ import { MetadataAtomic } from "../../../schemas/metadata/MetadataAtomic";
 import { MetadataConstant } from "../../../schemas/metadata/MetadataConstant";
 import { MetadataConstantValue } from "../../../schemas/metadata/MetadataConstantValue";
 import { MetadataTemplate } from "../../../schemas/metadata/MetadataTemplate";
+import { MetadataObject } from "../../../schemas/metadata/MetadataObject";
 
 import { ArrayUtil } from "../../../utils/ArrayUtil";
 
@@ -100,7 +101,7 @@ export const iterate_metadata_intersection =
         c.isRequired() === true &&
         c.objects.length &&
         c.objects.length === c.size() &&
-        c.objects.every((o) => o.properties.every((p) => p.value.optional)),
+        c.objects.every((o) => o.properties.every((p) =>  p.value.optional || p.value.objects.some(isNoRuntimeCheck))),
     );
     const arrays: Set<string> = new Set(
       individuals.map(([c]) => c.arrays.map((a) => a.type.name)).flat(),
@@ -211,3 +212,11 @@ export const iterate_metadata_intersection =
     }
     return true;
   };
+
+function isNoRuntimeCheck(meta: MetadataObject): boolean {
+  // This is a hack: there is probably a better, structured way to ensure Metadata describes
+  // a specific type, but I've not found it, nor di I have a need for it.
+  return Boolean(meta.properties[0]?.key.constants[0]?.values[0]?.value === 'typia.tag')
+    && meta.name.startsWith('NoRuntimeCheck');
+}
+

--- a/src/tags/NoRuntimeCheck.ts
+++ b/src/tags/NoRuntimeCheck.ts
@@ -1,0 +1,7 @@
+import { TagBase } from "./TagBase";
+
+export type NoRuntimeCheck<T extends string | number | boolean | bigint> = TagBase<{
+  target: T;
+  kind: "NoRuntimeCheck";
+  value: T;
+}>;

--- a/src/tags/index.ts
+++ b/src/tags/index.ts
@@ -13,6 +13,7 @@ export * from "./MinItems";
 export * from "./MinLength";
 export * from "./MultipleOf";
 export * from "./Pattern";
+export * from "./NoRuntimeCheck";
 export * from "./TagBase";
 export * from "./Type";
 export * from "./UniqueItems";


### PR DESCRIPTION
To install `npm i typia@npm:@matatbread/typia`.

Example:
```
import typia from "typia";

type B = number & ({ _brand: typia.tags.NoRuntimeCheck<'b'> });
type C = number & ({ _brand: typia.tags.NoRuntimeCheck<'c'> });

function x(a: number) {}
function y(a: B) {}
function z(a: C) {}

const b = 123 as B;

x(b); // Correct: b is a number
y(b); // Correct: b is a B
// @ts-expect-error
z(b); // Error (Correct!): b is not a C

console.log("Branding 1:",b * 10, typia.validate<B>(b)); // Correct: 1230
```
